### PR TITLE
all: fix misuses of math.Pow(x, 2)

### DIFF
--- a/cluster/distance.go
+++ b/cluster/distance.go
@@ -62,7 +62,8 @@ func EuclideanDistance(a, b mat.Vector) float64 {
 	}
 	var d2 float64
 	for j := 0; j < b.Len(); j++ {
-		d2 += math.Pow(b.AtVec(j)-a.AtVec(j), 2)
+		x := b.AtVec(j) - a.AtVec(j)
+		d2 += x * x
 	}
 	return math.Sqrt(d2)
 }

--- a/neighbors/distance.go
+++ b/neighbors/distance.go
@@ -62,7 +62,8 @@ func EuclideanDistance(a, b mat.Vector) float64 {
 	}
 	var d2 float64
 	for j := 0; j < b.Len(); j++ {
-		d2 += math.Pow(b.AtVec(j)-a.AtVec(j), 2)
+		x := b.AtVec(j) - a.AtVec(j)
+		d2 += x * x
 	}
 	return math.Sqrt(d2)
 }

--- a/preprocessing/data.go
+++ b/preprocessing/data.go
@@ -574,7 +574,8 @@ func DenseNormalize(X *mat.Dense, FitIntercept, Normalize bool) (XOffset, XScale
 		v := 0.
 		if Normalize {
 			for i := 0; i < nSamples; i++ {
-				v += math.Pow(X.At(i, j)-XOffset, 2)
+				x := X.At(i, j) - XOffset
+				v += x * x
 			}
 			v = math.Sqrt(v / float64(nSamples))
 		}


### PR DESCRIPTION
math.Pow(x, 2) is really inefficient because math.Pow(x, y) is written
for the general use case of computing the power of x where y is a
floating point number.
In the simpler case of y as an integer, a much simpler algorithm can be
used.
In the even simpler case of y==2, inlining is even faster.