### PR TITLE
pa-m:sklearn - Changed maxFev param type from int to int64 for 32-bit builds.

### DIFF
--- a/preprocessing/data.go
+++ b/preprocessing/data.go
@@ -1390,7 +1390,7 @@ func yeoJohnsonOptimize(x []float64) float64 {
 			(lmbda-1)*sumlog1p
 		return -loglike
 	}
-	maxFev := func(n int) bool { return n >= 500 }
+	maxFev := func(n int64) bool { return n >= 500 }
 	brent := optimize.NewBrentMinimizer(negLogLikelihood, 1.48e-8, math.MaxInt32, maxFev)
 
 	brent.Brack = []float64{-2, 2}
@@ -1487,7 +1487,7 @@ func boxCoxOptimize(x []float64) float64 {
 			(lmbda-1)*sumlog
 		return -loglike
 	}
-	maxFev := func(n int) bool { return n >= 500 }
+	maxFev := func(n int64) bool { return n >= 500 }
 	brent := optimize.NewBrentMinimizer(negLogLikelihood, 1.48e-8, math.MaxInt32, maxFev)
 
 	brent.Brack = []float64{-2, 2}


### PR DESCRIPTION
I'm using pa-m:sklearn/preprocessing StandardScaler and I get this error when trying to build for x86:
 - optimize/powell.go:34:16: constant 9223372036854775807 overflows int

To fix this, I have modified 3 files in pa-m:optimize and changed fnMaxFev param from type int to type int64 which is already in a separate PR

I also changed sklearn:preprocessing/data.go

After these changes I can successfully build for x86 without problems.
All tests are also passing.