### PR TITLE
Resolving the local path of the datasets using the build package

### DIFF
--- a/datasets/base.go
+++ b/datasets/base.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	// Dir stores the resolved import path of github.com/pa-m/sklearn
-	Dir string
+	// dir stores the resolved local path of github.com/pa-m/sklearn
+	dir string
 )
 
 func init() {
@@ -24,7 +24,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	Dir = pkg.Dir
+	dir = pkg.Dir
 }
 
 // MLDataset structure returned by LoadIris,LoadBreastCancer,LoadDiabetes,LoadBoston
@@ -100,7 +100,7 @@ func (ds *MLDataset) GetXY() (X, Y *mat.Dense) {
 }
 
 func localPath(s string) string {
-	p := strings.Split(Dir, string(filepath.ListSeparator))[0]
+	p := strings.Split(dir, string(filepath.ListSeparator))[0]
 	return filepath.Join(p, s)
 }
 

--- a/datasets/base.go
+++ b/datasets/base.go
@@ -14,6 +14,19 @@ import (
 	"gonum.org/v1/gonum/mat"
 )
 
+var (
+	// Dir stores the resolved import path of github.com/pa-m/sklearn
+	Dir string
+)
+
+func init() {
+	pkg, err := build.Import("github.com/pa-m/sklearn", ".", build.FindOnly)
+	if err != nil {
+		panic(err)
+	}
+	Dir = pkg.Dir
+}
+
 // MLDataset structure returned by LoadIris,LoadBreastCancer,LoadDiabetes,LoadBoston
 type MLDataset struct {
 	Data         [][]float64 `json:"data,omitempty"`
@@ -49,27 +62,27 @@ func loadJSON(filepath string) (ds *MLDataset) {
 
 // LoadIris load the iris dataset
 func LoadIris() (ds *MLDataset) {
-	return loadJSON(localPath("/src/github.com/pa-m/sklearn/datasets/data/iris.json"))
+	return loadJSON(localPath("datasets/data/iris.json"))
 }
 
 // LoadBreastCancer load the breat cancer dataset
 func LoadBreastCancer() (ds *MLDataset) {
-	return loadJSON(localPath("/src/github.com/pa-m/sklearn/datasets/data/cancer.json"))
+	return loadJSON(localPath("datasets/data/cancer.json"))
 }
 
 // LoadDiabetes load the diabetes dataset
 func LoadDiabetes() (ds *MLDataset) {
-	return loadJSON(localPath("/src/github.com/pa-m/sklearn/datasets/data/diabetes.json"))
+	return loadJSON(localPath("datasets/data/diabetes.json"))
 }
 
 // LoadBoston load the boston housing dataset
 func LoadBoston() (ds *MLDataset) {
-	return loadJSON(localPath("/src/github.com/pa-m/sklearn/datasets/data/boston.json"))
+	return loadJSON(localPath("datasets/data/boston.json"))
 }
 
 // LoadWine load the boston housing dataset
 func LoadWine() (ds *MLDataset) {
-	return loadJSON(localPath("/src/github.com/pa-m/sklearn/datasets/data/wine.json"))
+	return loadJSON(localPath("datasets/data/wine.json"))
 }
 
 // GetXY returns X,Y matrices for dataset
@@ -87,30 +100,30 @@ func (ds *MLDataset) GetXY() (X, Y *mat.Dense) {
 }
 
 func localPath(s string) string {
-	p := strings.Split(build.Default.GOPATH, string(filepath.ListSeparator))[0]
+	p := strings.Split(Dir, string(filepath.ListSeparator))[0]
 	return filepath.Join(p, s)
 }
 
 // LoadExamScore loads data from ex2data1 from Andrew Ng machine learning course
 func LoadExamScore() (X, Y *mat.Dense) {
-	return loadCsv(localPath("/src/github.com/pa-m/sklearn/datasets/data/ex2data1.txt"), nil, 1)
+	return loadCsv(localPath("datasets/data/ex2data1.txt"), nil, 1)
 
 }
 
 // LoadMicroChipTest loads data from ex2data2 from  Andrew Ng machine learning course
 func LoadMicroChipTest() (X, Y *mat.Dense) {
-	return loadCsv(localPath("/src/github.com/pa-m/sklearn/datasets/data/ex2data2.txt"), nil, 1)
+	return loadCsv(localPath("datasets/data/ex2data2.txt"), nil, 1)
 }
 
 // LoadMnist loads mnist data 5000x400,5000x1
 func LoadMnist() (X, Y *mat.Dense) {
-	mats := LoadOctaveBin(localPath("/src/github.com/pa-m/sklearn/datasets/data/ex4data1.dat.gz"))
+	mats := LoadOctaveBin(localPath("datasets/data/ex4data1.dat.gz"))
 	return mats["X"], mats["y"]
 }
 
 // LoadMnistWeights loads mnist weights
 func LoadMnistWeights() (Theta1, Theta2 *mat.Dense) {
-	mats := LoadOctaveBin(localPath("/src/github.com/pa-m/sklearn/datasets/data/ex4weights.dat.gz"))
+	mats := LoadOctaveBin(localPath("datasets/data/ex4weights.dat.gz"))
 	return mats["Theta1"], mats["Theta2"]
 }
 
@@ -144,7 +157,7 @@ func check(err error) {
 
 // LoadInternationalAirlinesPassengers ...
 func LoadInternationalAirlinesPassengers() (Y *mat.Dense) {
-	f, err := os.Open(realPath(os.Getenv("GOPATH") + "/src/github.com/pa-m/sklearn/datasets/data/international-airline-passengers.csv"))
+	f, err := os.Open(realPath(localPath("datasets/data/international-airline-passengers.csv")))
 	check(err)
 	defer f.Close()
 	fb := bufio.NewReader(f)

--- a/datasets/octave_test.go
+++ b/datasets/octave_test.go
@@ -2,7 +2,6 @@ package datasets
 
 import (
 	"math"
-	"os"
 	"testing"
 
 	"gonum.org/v1/gonum/floats"
@@ -11,7 +10,8 @@ import (
 
 func TestLoadOctaveBin(t *testing.T) {
 	// v https://lists.gnu.org/archive/html/help-octave/2004-11/msg00068.html
-	filename := os.Getenv("GOPATH") + "/src/github.com/pa-m/sklearn/datasets/data/ex4data1.dat.gz"
+	// dir variable has the local path of the package and gets initialized in the base.go file
+	filename := dir + "/datasets/data/ex4data1.dat.gz"
 	mats := LoadOctaveBin(filename)
 	if _, ok := mats["y"]; !ok {
 		t.Errorf("no y")

--- a/linear_model/Base.go
+++ b/linear_model/Base.go
@@ -623,7 +623,7 @@ func PreprocessData(X, Y *mat.Dense, FitIntercept, Normalize bool, SampleWeight 
 				Xout.Copy(X)
 			}
 			scale := 1.
-			if Normalize {
+			if FitIntercept && Normalize {
 				scale = mat.Norm(Xout.ColView(feature), 2)
 				if scale != 0. {
 					for jXout := 0; jXout < Xoutmat.Rows*Xoutmat.Stride; jXout = jXout + Xoutmat.Stride {


### PR DESCRIPTION
When accessing the datasets in projects outside the GOPATH using go modules, the location of the datasets used in the package doesn't match the actual location where they get stored.

So I took inspiration from this [post](https://dev.to/rhysd/til-how-to-resolve-go-import-paths-in-go-32dn) to arrive at a solution.

I am new to Go, if I made any obvious errors please do let me know I will try to correct them.